### PR TITLE
Add client.shutdown() when client.connect() return err

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,8 @@ Cassandra.prototype._ensureSchema = function (callback) {
   return this.client.connect(function (err) {
     if (err) {
       self.schemaStatus.err = err;
-      return callback(self.schemaStatus.err);
+      self.client.shutdown();
+      return callback(err);
     }
     return self._createSchema(callback);
   });


### PR DESCRIPTION
When client.connect() return err need to close connection with client.shutdown().
Otherwise client will try to reconnect.
